### PR TITLE
fix: Trim trailing whitespace from license/notice

### DIFF
--- a/.github/workflows/editorconfig-audit-ci.yml
+++ b/.github/workflows/editorconfig-audit-ci.yml
@@ -20,4 +20,4 @@ jobs:
           # check options you given the command-line. By removing the file, only
           # the given options are checked.
           git ls-files | grep -iF .editorconfig | xargs -t -n 1 rm
-          env node_modules/.bin/eclint check --insert_final_newline --trim_trailing_whitespace $(git ls-files | grep -viF .editorconfig | grep -viE "\.pb$" | grep -viE "NOTICE$")
+          env node_modules/.bin/eclint check --insert_final_newline --trim_trailing_whitespace $(git ls-files | grep -viF .editorconfig | grep -viE "\.pb$")

--- a/NOTICE
+++ b/NOTICE
@@ -1650,8 +1650,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # Licenses
 
 This Rust implementation of the OpenEXR image format
-and the exrs crate are not affiliated with the 
-[OpenEXR project](https://www.openexr.com/) or the 
+and the exrs crate are not affiliated with the
+[OpenEXR project](https://www.openexr.com/) or the
 [ACADEMY SOFTWARE FOUNDATION](https://www.aswf.io/).
 
 
@@ -1718,7 +1718,7 @@ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
 PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 
@@ -6735,7 +6735,7 @@ SOFTWARE.
 ```text
 The MIT License (MIT)
 
-Copyright (c) 2015 
+Copyright (c) 2015
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/applications/simulated-camera/LICENSE_IMAGES
+++ b/examples/applications/simulated-camera/LICENSE_IMAGES
@@ -43,18 +43,18 @@ effect of CC0 on those rights.
 
    3. publicity and privacy rights pertaining to a person’s image or likeness
       depicted in a Work;
-   
+
    4. rights protecting against unfair competition in regards to a Work,
       subject to the limitations in paragraph 4(i), below;
-   
+
    5. rights protecting the extraction, dissemination, use and reuse of data in
       a Work;
-   
+
    6. database rights (such as those arising under Directive 96/9/EC of the
       European Parliament and of the Council of 11 March 1996 on the legal
       protection of databases, and under any national implementation thereof,
       including any amended or successor version of such directive); and
-   
+
    7. other similar, equivalent or corresponding rights throughout the world
       based on applicable law or treaty, and any national implementations
       thereof.


### PR DESCRIPTION
## Motivation and Context

The CI pipeline is failing due to the following **EditorConfig** lint errors (see [run 3335759847](https://github.com/eclipse/chariott/actions/runs/3335759847), for example):

    examples/applications/simulated-camera/LICENSE_IMAGES
        46:01 ❌ unexpected trailing whitespace
                                                (EditorConfig trim_trailing_whitespace https://goo.gl/oo8iVb)
        49:01 ❌ unexpected trailing whitespace
                                                (EditorConfig trim_trailing_whitespace https://goo.gl/oo8iVb)
        52:01 ❌ unexpected trailing whitespace
                                                (EditorConfig trim_trailing_whitespace https://goo.gl/oo8iVb)
        57:01 ❌ unexpected trailing whitespace
                                                (EditorConfig trim_trailing_whitespace https://goo.gl/oo8iVb)


## Description

This PR:

- Trims trailing whitespace from the licenses and notices files.
- It also updates the lint filter to not exclude `NOTICE` since there's no need for the exception.
