### PR TITLE
fix: Trim trailing space in notices file during generation

### DIFF
--- a/tools/notice_generation.sh
+++ b/tools/notice_generation.sh
@@ -32,7 +32,7 @@ fi
 
 NOTICE_FILENAME="NOTICE"
 echo "Running cargo-about for NOTICE file generation..."
-cargo about generate --workspace devops/cg/about.hbs --config devops/cg/about.toml > $NOTICE_FILENAME
+cargo about generate --workspace devops/cg/about.hbs --config devops/cg/about.toml | sed -E 's/[ \t]+$//' > $NOTICE_FILENAME
 
 if [ -z "$(git diff --name-only $NOTICE_FILENAME)" ]
 then


### PR DESCRIPTION
## Motivation and Context

In PR #6, trailing whitespace was removed from the `NOTICE` file, but it risks returning next time the file is scheduled to be generated via [the **Notice generation** workflow](https://github.com/eclipse/chariott/blob/02ae33d40eb06dbff4a56f7ee150cca84bd62cec/.github/workflows/notice-generation.yaml). Trailing whitespace should therefore be removed during generation so that it does not fail [the **EditorConfig audit** workflow](https://github.com/eclipse/chariott/blob/02ae33d40eb06dbff4a56f7ee150cca84bd62cec/.github/workflows/editorconfig-audit-ci.yml).

## Description

This PR updates the notice generation script to trim trailing whitespace when the file is generated.
