### PR TITLE
fix: Remove invalid revision from Git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,0 @@
-# Reformat with "use_small_heuristics" set to "Max"
-71396929692d3ab2dfda767909869c847933534c


### PR DESCRIPTION
## Motivation and Context

The `.git-blame-ignore-revs` contains an invalid revision hash.

## Description

This PR removes the entire file since it only contained a single revision hash that was invalid. The file can be added back the next time such a revision needs to be tracked for ignoring during a `git blame`.
