### PR TITLE
fix: Fix notice generation script to quote PR title

### DIFF
--- a/tools/notice_generation.sh
+++ b/tools/notice_generation.sh
@@ -46,5 +46,5 @@ else
       git push -f --set-upstream origin "$BRANCH_NAME"
       ## token needs repo access and read:org
       echo "$GITHUB_PAT_TOKEN" | gh auth login --with-token
-      gh pr create -B main -H "$BRANCH_NAME" --title $PR_TITLE --body 'This PR is merging latest changes related to notice file. Please review them before approving.'
+      gh pr create -B main -H "$BRANCH_NAME" --title "$PR_TITLE" --body 'This PR is merging latest changes related to notice file. Please review them before approving.'
 fi


### PR DESCRIPTION
## Motivation and Context

The [`notice_generation` job failed yesterday](https://github.com/eclipse/chariott/actions/runs/3353732331/jobs/5556757646) due to the following error:

    unknown arguments ["Notice" "file" "change"]; please quote all values that have spaces

    Usage:  gh pr create [flags]
    …

This seems to stem from the following line:

https://github.com/eclipse/chariott/blob/ea87ae3555251b5b8e12459266b6ed9ae4ff9163/tools/notice_generation.sh#L49

## Description

This PR fixes the script by quoting `$PR_TITLE`.

---
- 📄 [`logs_60.zip`](https://github.com/eclipse/chariott/files/9900202/logs_60.zip)
