### PR TITLE
Update unit tests with cases for capital-case system upsert

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -376,6 +376,9 @@ pub(crate) mod tests {
         test("system.registry");
         test("system.foo");
         test("system.");
+        test("System");
+        test("SYSTEM");
+        test("SYSTEM.Registry");
 
         fn test(namespace: &str) {
             // arrange


### PR DESCRIPTION
## Description

We currently disallow providers to register intents for the `system*` namespaces. We prevent this case-insensitively, meaning that also `SYSTEM*` and all variations thereof are disallowed. The unit tests did not reflect this, with this PR we add more cases for additional coverage.
