### PR TITLE
Cancel in-progress runs for open PRs

### DIFF
--- a/.github/workflows/alex-recommends-ci.yml
+++ b/.github/workflows/alex-recommends-ci.yml
@@ -8,6 +8,10 @@ on:
       - '**.md'
       - '**.markdown'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   alex:
     runs-on: ubuntu-latest

--- a/.github/workflows/containerize.yaml
+++ b/.github/workflows/containerize.yaml
@@ -20,6 +20,10 @@ on:
       - "Dockerfile"
       - ".github/workflows/containerize.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -11,6 +11,10 @@ on:
       - 'examples/applications/dog-mode-ui/**'
       - '.github/workflows/dotnet-ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -16,6 +16,10 @@ on:
       - 'Cargo.lock'
       - 'Cargo.toml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/editorconfig-audit-ci.yml
+++ b/.github/workflows/editorconfig-audit-ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   editorconfig-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ess-bench.yml
+++ b/.github/workflows/ess-bench.yml
@@ -12,6 +12,10 @@ on:
       - 'ess/**'
       - '.github/workflows/ess-bench.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: write
   deployments: write

--- a/.github/workflows/lt-ci.yml
+++ b/.github/workflows/lt-ci.yml
@@ -17,6 +17,10 @@ on:
       - 'Cargo.lock'
       - 'Cargo.toml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: write
   deployments: write

--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -9,6 +9,10 @@ on:
       - '**.md'
       - '**.markdown'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint-markdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -19,6 +19,10 @@ on:
       - 'Cargo.lock'
       - 'Cargo.toml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -10,6 +10,11 @@ on:
   schedule:
     - cron: "0 0 * * *" # once a day at midnight UTC
     # NB: that cron trigger on GH actions runs only on the default branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves #18

## Motivation and Context

If we push multiple updates to an open PR, GitHub Action runs will start to queue up. Action runs for all pushes other than the latest do not add any value and can be cancelled.

## Description

We use [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow) to cancel any in-progress runs for an open PR.