### PR TITLE
Fix CI for PRs from clones

### DIFF
--- a/.github/workflows/ess-bench.yml
+++ b/.github/workflows/ess-bench.yml
@@ -19,8 +19,9 @@ permissions:
 env:
   # Push the results to gh-pages only on merge to main.
   AUTO_PUSH: ${{ github.event_name == 'push' }}
-  # Comment the performance numbers of the load tests only on PRs.
-  COMMENT_ALWAYS: ${{ github.event_name == 'pull_request' }}
+  # Comment the performance numbers of the load tests only on PRs and if the PR
+  # comes from within the Eclipse organization.
+  COMMENT_ALWAYS: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'eclipse/chariott' }}
 
 jobs:
   benchmark:

--- a/.github/workflows/lt-ci.yml
+++ b/.github/workflows/lt-ci.yml
@@ -26,7 +26,7 @@ env:
   AUTO_PUSH: ${{ github.event_name == 'push' }}
   # Comment the performance numbers of the load tests only on PRs and if the PR
   # comes from within the Eclipse organization.
-  COMMENT_ALWAYS: ${{ github.event_name == 'pull_request' && github.repository == 'eclipse/chariott' }}
+  COMMENT_ALWAYS: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'eclipse/chariott' }}
 
 jobs:
   benchmark:

--- a/.github/workflows/lt-ci.yml
+++ b/.github/workflows/lt-ci.yml
@@ -24,8 +24,9 @@ permissions:
 env:
   # Push the results to gh-pages only on merge to main.
   AUTO_PUSH: ${{ github.event_name == 'push' }}
-  # Comment the performance numbers of the load tests only on PRs.
-  COMMENT_ALWAYS: ${{ github.event_name == 'pull_request' }}
+  # Comment the performance numbers of the load tests only on PRs and if the PR
+  # comes from within the Eclipse organization.
+  COMMENT_ALWAYS: ${{ github.event_name == 'pull_request' && github.repository == 'eclipse/chariott' }}
 
 jobs:
   benchmark:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -74,7 +74,7 @@ jobs:
           name: code-coverage-report
           path: cobertura.xml
       - uses: 5monkeys/cobertura-action@master
-        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event_name == 'pull_request' && github.repository == 'eclipse/chariott' && github.actor != 'dependabot[bot]' }}
         with:
           path: cobertura.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -74,7 +74,7 @@ jobs:
           name: code-coverage-report
           path: cobertura.xml
       - uses: 5monkeys/cobertura-action@master
-        if: ${{ github.event_name == 'pull_request' && github.repository == 'eclipse/chariott' && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'eclipse/chariott' && github.actor != 'dependabot[bot]' }}
         with:
           path: cobertura.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #16

## Motivation and Context

GitHub Action runs for the Rust CI and Load Test CI fail from PRs that come from clones, due to the fact that those PRs do not get access to secrets with write permissions.

## Description

We disable the comments on the PR for the code coverage and the performance numbers for PRs from clones, as determined by the content of the [`pull_request` event](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request). The data is still available in the respective Action run as an artifact respectively a pipeline step. The numbers will have to be evaluated manually for PRs from clones.