### PR TITLE
Fix read-me section link + title typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Project Chariott
 
 - [What is Chariott?](#what-is-chariott)
-- [How to develop with Charriott](#how-to-develop-with-charriott)
+- [How to develop with Chariott](#how-to-develop-with-chariott)
   - [Terminology](#terminology)
   - [Concept of Intents](#concept-of-intents)
 - [Getting started](#getting-started)


### PR DESCRIPTION
## Motivation and Context

PR #17 fixed a typo in a section title, but it broken the link in the table of contents. Unfortunately, this did not get caught by the **[Lint and Check Markdown](https://github.com/eclipse/chariott/blob/6044c0cf92768a2dcc2a4f618744dbc98dc2305c/.github/workflows/markdown-ci.yml)** workflow.

## Description

This PR aligns title in the table of contents while also fixing the link.
