### PR TITLE
fix: Trim trailing whitespace from CRLF-terminated notice lines

### DIFF
--- a/tools/notice_generation.sh
+++ b/tools/notice_generation.sh
@@ -32,7 +32,7 @@ fi
 
 NOTICE_FILENAME="NOTICE"
 echo "Running cargo-about for NOTICE file generation..."
-cargo about generate --workspace devops/cg/about.hbs --config devops/cg/about.toml | sed -E 's/[ \t]+$//' > $NOTICE_FILENAME
+cargo about generate --workspace devops/cg/about.hbs --config devops/cg/about.toml | sed -E 's/[ \t]+\r?$//' > $NOTICE_FILENAME
 
 if [ -z "$(git diff --name-only $NOTICE_FILENAME)" ]
 then


### PR DESCRIPTION
## Motivation and Context

This is a follow-up PR to #7. Some notices seem to have lines terminated with `CR`+`LF`, which causes the regular expression that trims trailing whitespace to miss them and consequently the [EC lint check to fail](https://github.com/eclipse/chariott/actions/runs/3413956830/jobs/5681283629).

## Description

The regular expression has been updated to account for `CR` and remove it along with any trailing whitespace.