### PR TITLE
Do not install Tarpaulin from Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,7 +42,3 @@ COPY ../rust-toolchain .
 RUN rustup override set $(cat rust-toolchain) && \
     rustup component add clippy && \
     rustup component add rustfmt
-
-# The following takes a long time to complete.
-# We use a separate layer to hit the (layer) cache if possible.
-RUN cargo install cargo-tarpaulin


### PR DESCRIPTION
Fixes #33

## Description

Tarpaulin [cannot be compiled on Docker on M1 MacBooks](https://github.com/xd009642/tarpaulin/issues/549#issuecomment-1198600914) but has an [(unreleased) fix ready for this issue](https://github.com/xd009642/tarpaulin/issues/549#issuecomment-1291096269). As long as it's not yet released, we do not install Tarpaulin with the Devcontainer.

We track reinstalling Tarpaulin in #39.
