### PR TITLE
Fix CI workflow to install .NET 6

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.11
+          dotnet-version: 6.0.403
           global-json-file: examples/applications/dog-mode-ui/global.json
 
       - run: dotnet --info

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -23,6 +23,9 @@ jobs:
 
       - uses: actions/setup-dotnet@v2
         with:
+          dotnet-version: 6.0.11
           global-json-file: examples/applications/dog-mode-ui/global.json
+
+      - run: dotnet --info
 
       - run: dotnet build examples/applications/dog-mode-ui


### PR DESCRIPTION
## Motivation and Context

In PR #49, the .NET SDK was updated to version 7, but the application still target .NET 6 (LTS) runtime. The .NET 6 (LTS) runtime could be/go missing from the CI host.

## Description

The workflow is updated to install the .NET 6 as well.
