### PR TITLE
Install dependencies required for Paho MQTT in Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@
 ARG VARIANT="bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
+# `libssl-dev`, `build-essential` and `clang` are required for Paho MQTT
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends git-lfs cmake protobuf-compiler libprotobuf-dev libssl-dev build-essential clang
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ ARG VARIANT="bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends git-lfs cmake protobuf-compiler libprotobuf-dev
+    && apt-get -y install --no-install-recommends git-lfs cmake protobuf-compiler libprotobuf-dev libssl-dev build-essential cmake clang
 
 RUN mkdir /usr/bin/grpcurl.d \
     && curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz | tar -xvz --directory /usr/bin/grpcurl.d \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ ARG VARIANT="bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends git-lfs cmake protobuf-compiler libprotobuf-dev libssl-dev build-essential cmake clang
+    && apt-get -y install --no-install-recommends git-lfs cmake protobuf-compiler libprotobuf-dev libssl-dev build-essential clang
 
 RUN mkdir /usr/bin/grpcurl.d \
     && curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz | tar -xvz --directory /usr/bin/grpcurl.d \


### PR DESCRIPTION
## Description

With this PR we install the dependencies required for building the Car Bridge inside the Devcontainer. This is an omission from #60.