### PR TITLE
Attempt to complete all in-flight tasks when shutting down Car Bridge

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -9,6 +9,7 @@ on:
       - main
       - cloud-bridge
     paths:
+      - 'car-bridge/**'
       - 'common/**'
       - 'src/**'
       - 'tests/**'

--- a/car-bridge/src/drainage.rs
+++ b/car-bridge/src/drainage.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 use futures::Future;
 use tokio::{
     spawn,

--- a/car-bridge/src/drainage.rs
+++ b/car-bridge/src/drainage.rs
@@ -1,0 +1,65 @@
+use futures::Future;
+use tokio::{
+    spawn,
+    sync::mpsc::{self, Receiver, Sender},
+    task::JoinHandle,
+};
+
+/// Spawn tasks on the `Drainage` to ensure that the task completed when
+/// shutting down. Based on https://tokio.rs/tokio/topics/shutdown
+pub struct Drainage {
+    drained_receiver: Receiver<()>,
+    drained_sender: Sender<()>,
+}
+
+impl Drainage {
+    pub fn new() -> Self {
+        let (drained_sender, drained_receiver) = mpsc::channel(1);
+        Self { drained_receiver, drained_sender }
+    }
+
+    /// Spawns a task while allowing to wait for it to complete when calling
+    /// `drain`.
+    pub fn spawn<F>(&self, f: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send,
+    {
+        let sender = self.drained_sender.clone();
+
+        spawn(async move {
+            let result = f.await;
+            drop(sender);
+            result
+        })
+    }
+
+    /// Waits for all tasks that were spawned via this drainage to finish.
+    pub async fn drain(mut self) {
+        drop(self.drained_sender);
+        _ = self.drained_receiver.recv().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::Drainage;
+    use tokio::time::sleep;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn drain_when_task_is_active_times_out() {
+        let drainage = Drainage::new();
+        _ = drainage.spawn(sleep(Duration::from_millis(500)));
+        assert!(timeout(Duration::from_millis(100), drainage.drain()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn drain_when_no_task_is_active_succeeds() {
+        let drainage = Drainage::new();
+        _ = drainage.spawn(sleep(Duration::from_millis(100)));
+        assert!(timeout(Duration::from_millis(500), drainage.drain()).await.is_ok());
+    }
+}

--- a/car-bridge/src/drainage.rs
+++ b/car-bridge/src/drainage.rs
@@ -9,7 +9,7 @@ use tokio::{
 };
 
 /// Spawn tasks on the `Drainage` to ensure that the task completed when
-/// shutting down. Based on https://tokio.rs/tokio/topics/shutdown
+/// shutting down.
 pub struct Drainage {
     drained_receiver: Receiver<()>,
     drained_sender: Sender<()>,
@@ -41,7 +41,8 @@ impl Drainage {
     pub async fn drain(mut self) {
         drop(self.drained_sender);
         // As soon as every sender is dropped, the channel is closed and the
-        // receiver receives a message.
+        // receiver receives a message. Based on:
+        // https://tokio.rs/tokio/topics/shutdown
         // https://docs.rs/tokio/latest/tokio/sync/mpsc/#disconnection
         _ = self.drained_receiver.recv().await;
     }

--- a/car-bridge/src/drainage.rs
+++ b/car-bridge/src/drainage.rs
@@ -37,6 +37,9 @@ impl Drainage {
     /// Waits for all tasks that were spawned via this drainage to finish.
     pub async fn drain(mut self) {
         drop(self.drained_sender);
+        // As soon as every sender is dropped, the channel is closed and the
+        // receiver receives a message.
+        // https://docs.rs/tokio/latest/tokio/sync/mpsc/#disconnection
         _ = self.drained_receiver.recv().await;
     }
 }

--- a/car-bridge/src/drainage.rs
+++ b/car-bridge/src/drainage.rs
@@ -41,7 +41,7 @@ impl Drainage {
     pub async fn drain(mut self) {
         drop(self.drained_sender);
         // As soon as every sender is dropped, the channel is closed and the
-        // receiver receives a message. Based on:
+        // reception fails. Based on:
         // https://tokio.rs/tokio/topics/shutdown
         // https://docs.rs/tokio/latest/tokio/sync/mpsc/#disconnection
         _ = self.drained_receiver.recv().await;

--- a/car-bridge/src/main.rs
+++ b/car-bridge/src/main.rs
@@ -18,7 +18,7 @@ use messaging::{MqttMessaging, Publisher, Subscriber};
 use paho_mqtt::{Message as MqttMessage, MessageBuilder, Properties, PropertyCode, QOS_2};
 use prost::Message;
 use tokio::{
-    select,
+    select, spawn,
     sync::mpsc::{self, Sender},
     time::timeout,
 };
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     break;
                 };
 
-                drainage.spawn(handle_message(chariott.clone(), response_sender.clone(), message));
+                spawn(handle_message(chariott.clone(), response_sender.clone(), message));
             }
             message = response_receiver.recv() => {
                 let Some((topic, message)) = message else {

--- a/car-bridge/src/main.rs
+++ b/car-bridge/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use chariott_common::{
     chariott_api::{ChariottCommunication, GrpcChariott},
@@ -13,18 +13,21 @@ use chariott_proto::{
     common::{IntentEnum, ValueEnum, ValueMessage},
     runtime::FulfillRequest,
 };
+use drainage::Drainage;
 use messaging::{MqttMessaging, Publisher, Subscriber};
 use paho_mqtt::{Message as MqttMessage, MessageBuilder, Properties, PropertyCode, QOS_2};
 use prost::Message;
 use tokio::{
-    select, spawn,
+    select,
     sync::mpsc::{self, Sender},
+    time::timeout,
 };
 use tokio_stream::StreamExt as _;
 use tracing::{debug, warn, Level};
 use tracing_subscriber::{util::SubscriberInitExt as _, EnvFilter};
 use url::Url;
 
+mod drainage;
 mod messaging;
 
 const VIN_ENV_NAME: &str = "VIN";
@@ -32,6 +35,7 @@ const DEFAULT_VIN: &str = "1";
 const BROKER_URL_ENV_NAME: &str = "BROKER_URL";
 const DEFAULT_BROKER_URL: &str = "tcp://localhost:1883";
 const PUBLISH_BUFFER: usize = 50;
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -53,9 +57,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut messages = client.subscribe(format!("c2d/{vin}")).await?;
     let client = Arc::new(client);
 
-    // TODO: cancellation currently does not result in trying to drain all
-    // in-flight publishing messages.
     let cancellation_token = ctrl_c_cancellation();
+    let drainage = Drainage::new();
 
     let (response_sender, mut response_receiver) = mpsc::channel(PUBLISH_BUFFER);
 
@@ -66,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     break;
                 };
 
-                spawn(handle_message(chariott.clone(), response_sender.clone(), message));
+                drainage.spawn(handle_message(chariott.clone(), response_sender.clone(), message));
             }
             message = response_receiver.recv() => {
                 let Some((topic, message)) = message else {
@@ -76,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let client = Arc::clone(&client);
 
-                spawn(async move {
+                drainage.spawn(async move {
                     if let Err(e) = client.publish(topic, message).await {
                         debug!("Error when publishing message: '{:?}'.", e);
                     }
@@ -87,6 +90,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 break;
             }
         }
+    }
+
+    if timeout(DRAIN_TIMEOUT, drainage.drain()).await.is_err() {
+        warn!("In-flight tasks could not be drained within {} seconds.", DRAIN_TIMEOUT.as_secs());
     }
 
     client.disconnect().await?;

--- a/car-bridge/src/main.rs
+++ b/car-bridge/src/main.rs
@@ -79,11 +79,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let client = Arc::clone(&client);
 
-                drainage.spawn(async move {
+                spawn(drainage.track(async move {
                     if let Err(e) = client.publish(topic, message).await {
                         debug!("Error when publishing message: '{:?}'.", e);
                     }
-                });
+                }));
             }
             _ = cancellation_token.cancelled() => {
                 debug!("Shutting down.");


### PR DESCRIPTION
## Motivation and Context

When shutting down the Car Bridge we want to finish publishing as many messages as possible. Since we detach the message handling and publishing of tasks, it is possible that if the Car Bridge shuts down, there are in-flight messages that were not yet processed.

## Description

With this PR we attempt to finish processing these in-flight messages. The approach is based on an `mpsc` channel as described in the [Tokio docs](https://tokio.rs/tokio/topics/shutdown).