### PR TITLE
Trigger Rust CI when `car-bridge` changed

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -9,6 +9,7 @@ on:
       - main
       - cloud-bridge
     paths:
+      - 'car-bridge/**'
       - 'common/**'
       - 'src/**'
       - 'tests/**'


### PR DESCRIPTION
## Description

We want to run the Rust CI when the `car-bridge` directory contains changes.