### PR TITLE
Support cancellation of `handle_message`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/car-bridge/Cargo.toml
+++ b/car-bridge/Cargo.toml
@@ -15,6 +15,7 @@ paho-mqtt = { version = "0.11", features = ["build_bindgen", "bundled", "ssl"] }
 prost = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/car-bridge/src/drainage.rs
+++ b/car-bridge/src/drainage.rs
@@ -17,8 +17,7 @@ impl Drainage {
         Self { drained_receiver, drained_sender }
     }
 
-    /// Tracks a future to allow waiting for it to complete when calling
-    /// `drain`.
+    /// Tracks a future to allow waiting for it to complete.
     pub fn track<F>(&self, f: F) -> impl Future<Output = F::Output>
     where
         F: Future + Send + 'static,

--- a/car-bridge/src/main.rs
+++ b/car-bridge/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         select! {
-            message = messages.next(), if !cancellation_token.is_cancelled() => {
+            message = messages.next(), if !shutdown_handled => {
                 let Some(message) = message else {
                     break;
                 };

--- a/car-bridge/src/main.rs
+++ b/car-bridge/src/main.rs
@@ -76,6 +76,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             message = response_receiver.recv() => {
                 let Some((topic, message)) = message else {
+                    // All senders are dropped and hence the channel is closed.
+                    // This shuts down the Car Bridge.
                     debug!("Response receiver stopped, no more messages will be published.");
                     break;
                 };

--- a/car-bridge/src/main.rs
+++ b/car-bridge/src/main.rs
@@ -6,7 +6,7 @@ use std::{sync::Arc, time::Duration};
 use chariott_common::{
     chariott_api::{ChariottCommunication, GrpcChariott},
     config::env,
-    error::Error,
+    error::{Error, ResultExt as _},
     shutdown::ctrl_c_cancellation,
 };
 use chariott_proto::{
@@ -23,6 +23,7 @@ use tokio::{
     time::timeout,
 };
 use tokio_stream::StreamExt as _;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn, Level};
 use tracing_subscriber::{util::SubscriberInitExt as _, EnvFilter};
 use url::Url;
@@ -69,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     break;
                 };
 
-                spawn(handle_message(chariott.clone(), response_sender.clone(), message));
+                spawn(handle_message(chariott.clone(), response_sender.clone(), message, cancellation_token.child_token()));
             }
             message = response_receiver.recv() => {
                 let Some((topic, message)) = message else {
@@ -105,6 +106,7 @@ async fn handle_message(
     mut chariott: impl ChariottCommunication,
     response_sender: Sender<(String, MessageBuilder)>,
     message: MqttMessage,
+    cancellation_token: CancellationToken,
 ) {
     let correlation_information = match message.get_correlation_information() {
         Ok(cm) => cm,
@@ -114,8 +116,9 @@ async fn handle_message(
         }
     };
 
-    let response: Result<_, Box<dyn std::error::Error + Send + Sync>> = async {
-        let fulfill_request: FulfillRequest = Message::decode(message.payload())?;
+    let response = async {
+        let fulfill_request: FulfillRequest =
+            Message::decode(message.payload()).map_err_with("Error when decoding payload.")?;
 
         let intent_enum = fulfill_request
             .intent
@@ -132,15 +135,19 @@ async fn handle_message(
         }?;
 
         let mut payload = vec![];
-        response.encode(&mut payload)?;
+        response.encode(&mut payload).map_err_with("Could not encode response.")?;
 
         Ok(Response {
             payload,
             content_type: "application/x-proto+chariott.common.v1.FulfillResponse",
             is_error: false,
         })
-    }
-    .await;
+    };
+
+    let response: Result<_, Error> = select! {
+        response = response => response,
+        _ = cancellation_token.cancelled() => Err(Error::new("Operation was cancelled."))
+    };
 
     let response = match response {
         Ok(message) => message,

--- a/car-bridge/src/main.rs
+++ b/car-bridge/src/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }));
             }
             _ = cancellation_token.cancelled(), if !cancellation_handled => {
+                // TODO: stop the MQTT client to consume messages.
                 debug!("Shutting down.");
                 // Swapping out the sender will ensure that the
                 // `response_receiver` gets closed as soon as all


### PR DESCRIPTION
## Description

With this PR we support cancelling in-flight `handle_message` tasks. When cancellation is requested, all in-flight fulfillment `Future`s against Chariott are dropped and instead an error is returned. When shutting down, all errors are (attempted to be) delivered to the MQTT broker to notify applications that the operation was cancelled.