### PR TITLE
Update License Banners according to Eclipse guidelines

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.231.5/containers/rust/.devcontainer/base.Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder
 
-# Dockerfile for building Chariott runtime container
+# Dockerfile for building Eclipse Chariott runtime container
 #
 # This Dockerfile utilizes a two step build process. It builds Chariott with
 # statically linked dependencies (using musl) for a x86_64 architecture.

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -5,7 +5,7 @@
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder
 
-# Dockerfile for building SDV Chariott container for ARM64 with
+# Dockerfile for building Eclipse Chariott container for ARM64 with
 # cross-compilation.
 #
 # This Dockerfile utilizes a two step build process. It builds the with

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,5 +1,6 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder

--- a/Dockerfile.valgrind
+++ b/Dockerfile.valgrind
@@ -5,7 +5,7 @@
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder
 
-# Dockerfile for building SDV Chariott container
+# Dockerfile for building Eclipse Chariott container
 #
 # This Dockerfile utilizes a two step build process. It builds Chariott with
 # statically linked dependencies (using musl vs. glibc to accomplish this) for a

--- a/Dockerfile.valgrind
+++ b/Dockerfile.valgrind
@@ -1,5 +1,6 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Project Chariott
+# Project Eclipse Chariott
 
 - [CI Status](#ci-status)
 - [What is Chariott?](#what-is-chariott)

--- a/build-all-containers.sh
+++ b/build-all-containers.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 set -e
 

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::fmt::Debug;
 use std::str::FromStr;

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::fmt::Display;
 

--- a/common/src/ext.rs
+++ b/common/src/ext.rs
@@ -1,6 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Portions Copyright (c) 2014 Jorge Aparicio
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 pub trait OptionExt<T, E> {
     fn ok(self) -> Result<Option<T>, E>;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 //! # Overview
 //! Common code (types and functions) for the different sdvlib crates.

--- a/common/src/query.rs
+++ b/common/src/query.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use regex::Regex;
 

--- a/common/src/shutdown.rs
+++ b/common/src/shutdown.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::net::SocketAddr;
 use tokio::{signal::ctrl_c, spawn};

--- a/common/src/streaming_ess.rs
+++ b/common/src/streaming_ess.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{ops::Deref, sync::Arc, time::SystemTime};
 

--- a/common/src/tokio_runtime_fork.rs
+++ b/common/src/tokio_runtime_fork.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use tokio_util::sync::CancellationToken;
 

--- a/ess/src/ess.rs
+++ b/ess/src/ess.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::borrow::Borrow;
 use std::collections::HashMap;

--- a/ess/src/lib.rs
+++ b/ess/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod ess;
 pub use crate::ess::*;

--- a/examples/applications/Dockerfile.base
+++ b/examples/applications/Dockerfile.base
@@ -5,7 +5,7 @@
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder
 
-# Dockerfile for building Chariott base image
+# Dockerfile for building Eclipse Chariott base image
 #
 # This Dockerfile builds the packages from chariott workspace with
 # statically linked dependencies (using musl) for x86_64 architecture

--- a/examples/applications/Dockerfile.base
+++ b/examples/applications/Dockerfile.base
@@ -1,5 +1,6 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder

--- a/examples/applications/Dockerfile.kv-app.ci
+++ b/examples/applications/Dockerfile.kv-app.ci
@@ -5,7 +5,7 @@
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder
 
-# Dockerfile for building SDV Chariott container
+# Dockerfile for building Eclipse Chariott container
 #
 # This Dockerfile utilizes a two step build process. It builds Chariott with
 # statically linked dependencies (using musl vs. glibc to accomplish this) for a

--- a/examples/applications/Dockerfile.kv-app.ci
+++ b/examples/applications/Dockerfile.kv-app.ci
@@ -1,5 +1,6 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder

--- a/examples/applications/Dockerfile.lt-provider-app.ci
+++ b/examples/applications/Dockerfile.lt-provider-app.ci
@@ -5,7 +5,7 @@
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder
 
-# Dockerfile for building SDV Chariott container
+# Dockerfile for building Eclipse Chariott container
 #
 # This Dockerfile utilizes a two step build process. It builds Chariott with
 # statically linked dependencies (using musl vs. glibc to accomplish this) for a

--- a/examples/applications/Dockerfile.lt-provider-app.ci
+++ b/examples/applications/Dockerfile.lt-provider-app.ci
@@ -1,5 +1,6 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 ARG RUST_VERSION=1.65
 FROM rust:${RUST_VERSION} AS builder

--- a/examples/applications/cloud-object-detection/src/chariott_provider.rs
+++ b/examples/applications/cloud-object-detection/src/chariott_provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+/// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use async_trait::async_trait;
 use chariott_proto::{

--- a/examples/applications/cloud-object-detection/src/detection.rs
+++ b/examples/applications/cloud-object-detection/src/detection.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use chariott_common::error::{Error, ResultExt};
 use examples_common::examples::detection::{DetectRequest, DetectResponse, DetectionObject};

--- a/examples/applications/cloud-object-detection/src/main.rs
+++ b/examples/applications/cloud-object-detection/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod chariott_provider;
 mod detection;

--- a/examples/applications/dog-mode-logic/src/dog_mode_status.rs
+++ b/examples/applications/dog-mode-logic/src/dog_mode_status.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use anyhow::{anyhow, Error};
 use async_stream::try_stream;

--- a/examples/applications/dog-mode-logic/src/main.rs
+++ b/examples/applications/dog-mode-logic/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{
     fmt::Display,

--- a/examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh
+++ b/examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 set -e
 # run a loop to oscillate temperature

--- a/examples/applications/dog-mode-ui/src/Program.cs
+++ b/examples/applications/dog-mode-ui/src/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 using System.Collections;
 using System.Collections.Specialized;

--- a/examples/applications/dog-mode-ui/src/wwwroot/index.css
+++ b/examples/applications/dog-mode-ui/src/wwwroot/index.css
@@ -1,5 +1,6 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved.
+/* Copyright (c) Microsoft Corporation.
  * Licensed under the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 * {
     font-size: 10vw;

--- a/examples/applications/dog-mode-ui/src/wwwroot/streaming.html
+++ b/examples/applications/dog-mode-ui/src/wwwroot/streaming.html
@@ -1,6 +1,7 @@
 <!--
-Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
+SPDX-License-Identifier: MIT
 -->
 <!DOCTYPE html>
 <html>

--- a/examples/applications/invoke-command/README.md
+++ b/examples/applications/invoke-command/README.md
@@ -1,6 +1,6 @@
 # Invoke Command Example
 
-This is an example Chariott provider that shows how the invoke intent works.
+This is an example provider that shows how the invoke intent works.
 It shows an example of a command that takes a json string as an input.
 
 ## Testing

--- a/examples/applications/invoke-command/src/chariott_provider.rs
+++ b/examples/applications/invoke-command/src/chariott_provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{collections::HashMap};
 

--- a/examples/applications/invoke-command/src/main.rs
+++ b/examples/applications/invoke-command/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod chariott_provider;
 

--- a/examples/applications/invoke_object_detection.sh
+++ b/examples/applications/invoke_object_detection.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 set -e
 cd "$(dirname "$(readlink -f "$0")")"

--- a/examples/applications/kv-app/README.md
+++ b/examples/applications/kv-app/README.md
@@ -1,6 +1,6 @@
 # Key-Value Store Application
 
-This is an example Chariott provider that offers the capability to read from
+This is an example provider that offers the capability to read from
 and write to an in-memory key-value store. It also supports subscribing to
 changes in the key store where the events are delivered over an opened
 channel.

--- a/examples/applications/kv-app/src/chariott_provider.rs
+++ b/examples/applications/kv-app/src/chariott_provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/examples/applications/kv-app/src/main.rs
+++ b/examples/applications/kv-app/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod chariott_provider;
 

--- a/examples/applications/local-object-detection/src/chariott_provider.rs
+++ b/examples/applications/local-object-detection/src/chariott_provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use async_trait::async_trait;
 use chariott_proto::{

--- a/examples/applications/local-object-detection/src/detection.rs
+++ b/examples/applications/local-object-detection/src/detection.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use chariott_common::error::Error;
 use examples_common::examples::detection::{DetectRequest, DetectResponse, DetectionObject};

--- a/examples/applications/local-object-detection/src/main.rs
+++ b/examples/applications/local-object-detection/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod chariott_provider;
 mod detection;

--- a/examples/applications/lt-consumer/src/main.rs
+++ b/examples/applications/lt-consumer/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use bollard::{container::StatsOptions, Docker};
 use chariott_common::{

--- a/examples/applications/lt-provider/src/main.rs
+++ b/examples/applications/lt-provider/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{
     sync::{Arc, Mutex},

--- a/examples/applications/mock-vas/src/chariott_provider.rs
+++ b/examples/applications/mock-vas/src/chariott_provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/examples/applications/mock-vas/src/communication.rs
+++ b/examples/applications/mock-vas/src/communication.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use chariott_common::shutdown::{ctrl_c_cancellation, RouterExt};
 use futures::future::join_all;

--- a/examples/applications/mock-vas/src/main.rs
+++ b/examples/applications/mock-vas/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod chariott_provider;
 mod communication;

--- a/examples/applications/mock-vas/src/simulation.rs
+++ b/examples/applications/mock-vas/src/simulation.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use chariott_common::error::{Error, ResultExt};
 use examples_common::chariott::value::Value;

--- a/examples/applications/proto/examples/detection/v1/detection.proto
+++ b/examples/applications/proto/examples/detection/v1/detection.proto
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 syntax = "proto3";
 

--- a/examples/applications/run_demo.sh
+++ b/examples/applications/run_demo.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 set -e
 cd "$(dirname "$0")/../.."

--- a/examples/applications/simulated-camera/src/camera.rs
+++ b/examples/applications/simulated-camera/src/camera.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use async_stream::try_stream;
 use chariott_common::error::Error;

--- a/examples/applications/simulated-camera/src/chariott_provider.rs
+++ b/examples/applications/simulated-camera/src/chariott_provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/examples/applications/simulated-camera/src/communication.rs
+++ b/examples/applications/simulated-camera/src/communication.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::sync::Arc;
 use std::{env::args, net::SocketAddr};

--- a/examples/applications/simulated-camera/src/main.rs
+++ b/examples/applications/simulated-camera/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod camera;
 mod chariott_provider;

--- a/examples/common/build.rs
+++ b/examples/common/build.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{error::Error, path::Path};
 use tonic_build::configure;

--- a/examples/common/src/chariott/api.rs
+++ b/examples/common/src/chariott/api.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 // api.rs contains code that can be considered "boilerplate" when
 // interacting with the Chariott runtime. It will most likely need to be

--- a/examples/common/src/chariott/inspection.rs
+++ b/examples/common/src/chariott/inspection.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{borrow::Borrow, collections::HashMap};
 

--- a/examples/common/src/chariott/mod.rs
+++ b/examples/common/src/chariott/mod.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 pub mod api;
 pub mod inspection;

--- a/examples/common/src/chariott/provider.rs
+++ b/examples/common/src/chariott/provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 #[macro_export]
 macro_rules! chariott_provider_main {

--- a/examples/common/src/chariott/registration.rs
+++ b/examples/common/src/chariott/registration.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{env, net::SocketAddr, time::Duration};
 

--- a/examples/common/src/chariott/streaming.rs
+++ b/examples/common/src/chariott/streaming.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use chariott_common::streaming_ess::StreamingEss;
 use chariott_proto::common::{

--- a/examples/common/src/chariott/value.rs
+++ b/examples/common/src/chariott/value.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{error::Error, fmt::Display};
 

--- a/examples/common/src/examples/detection.rs
+++ b/examples/common/src/examples/detection.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use chariott_common::error::{Error, ResultExt};
 use chariott_proto::common::{Blob, InvokeFulfillment, InvokeIntent};

--- a/examples/common/src/examples/mod.rs
+++ b/examples/common/src/examples/mod.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 /// Modules in `examples` are not common to Chariott in general, but common to
 /// one of our examples. The sub-modules illustrate how shared code between

--- a/examples/common/src/examples/proto.rs
+++ b/examples/common/src/examples/proto.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod chariott {
     pub mod common {

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 pub mod chariott;
 pub mod examples;

--- a/examples/common/src/url.rs
+++ b/examples/common/src/url.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{
     error::Error,

--- a/keyvalue/src/key_value_store.rs
+++ b/keyvalue/src/key_value_store.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::borrow::Borrow;
 use std::collections::HashMap;

--- a/keyvalue/src/lib.rs
+++ b/keyvalue/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 //! In Memory Key Value Store
 //!

--- a/proto.rs/build.rs
+++ b/proto.rs/build.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{error::Error, path::Path};
 use tonic_build::configure;

--- a/proto.rs/src/lib.rs
+++ b/proto.rs/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 // see https://github.com/hyperium/tonic/issues/1056
 // and https://github.com/tokio-rs/prost/issues/661#issuecomment-1156606409

--- a/proto/chariott/common/v1/common.proto
+++ b/proto/chariott/common/v1/common.proto
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 /**
 * Common Messages for the Chariott runtime.

--- a/proto/chariott/provider/v1/provider.proto
+++ b/proto/chariott/provider/v1/provider.proto
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 /**
 * Provider definition

--- a/proto/chariott/runtime/v1/runtime.proto
+++ b/proto/chariott/runtime/v1/runtime.proto
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 /**
 * Chariott Runtime

--- a/proto/chariott/streaming/v1/streaming.proto
+++ b/proto/chariott/streaming/v1/streaming.proto
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 /**
 * The streaming contract between applications

--- a/src/chariott_grpc.rs
+++ b/src/chariott_grpc.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::sync::{Arc, RwLock};
 use std::time::Instant;

--- a/src/connection_provider.rs
+++ b/src/connection_provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::sync::Arc;
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::collections::HashMap;
 

--- a/src/intent_broker.rs
+++ b/src/intent_broker.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{
     collections::HashMap,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 pub mod chariott_grpc;
 mod connection_provider;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use chariott::chariott_grpc::ChariottServer;
 use chariott::registry::{self, Registry};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use core::fmt;
 use std::collections::{HashMap, HashSet};

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 pub type StreamingEss = chariott_common::streaming_ess::StreamingEss<()>;

--- a/tests/chariott_integration.rs
+++ b/tests/chariott_integration.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Instant;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 pub fn get_uuid() -> Box<str> {
     uuid::Uuid::new_v4().to_string().into()

--- a/tests/container-e2e-tests-wsl2.sh
+++ b/tests/container-e2e-tests-wsl2.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 # This script is used to run the container e2e tests on WSL2
 # inside of the containers. It will provision a network and

--- a/tests/cover.sh
+++ b/tests/cover.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 set -e
 cd "$(dirname "$0")"

--- a/tests/provider.rs
+++ b/tests/provider.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 

--- a/tests/registry-e2e.rs
+++ b/tests/registry-e2e.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::time::Duration;
 

--- a/tests/store-e2e.rs
+++ b/tests/store-e2e.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 use std::{collections::HashSet, error::Error as _, time::Duration};
 

--- a/tools/charc
+++ b/tools/charc
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 set -e
 

--- a/tools/notice_generation.sh
+++ b/tools/notice_generation.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT

--- a/tools/notice_generation.sh
+++ b/tools/notice_generation.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
-# Copyright (c) Microsoft Corporation. All rights reserved.
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
 
 set -e
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Closes #94 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Description
Update License Banners according to Eclipse guidelines. The following is a sample of what they should look like:

`// Copyright (c) Microsoft Corporation.  

// Licensed under the MIT license.

// SPDX-License-Identifier: MIT`

**PR COMMIT MESSAGE**

<type>docs: Update License Banners according to Eclipse guidelines </description>
