### PR TITLE
Add example showing how to register a provider with Chariott

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-provider"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chariott-common",
+ "chariott-proto",
+ "ess",
+ "examples-common",
+ "keyvalue",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "simulated-camera-app"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "examples/applications/lt-consumer",
     "examples/applications/lt-provider",
     "examples/applications/mock-vas",
+    "examples/applications/simple-provider",
     "examples/applications/simulated-camera",
     "examples/common",
     "keyvalue",

--- a/examples/applications/README.md
+++ b/examples/applications/README.md
@@ -121,6 +121,10 @@ sequenceDiagram
    crashed between two announcements, it will respond with `ANNOUNCED`, in which
    case the provider should reregister using the `RegisterRequest`.
 
+See the [Simple Provider Application][simple-provider] for a self-contained example for how to implement the above pattern.
+
+[simple-provider]: ./simple-provider/README.md
+
 ### Vehicle integration
 
 This scenario illustrates how you can integrate the vehicle hardware when using

--- a/examples/applications/invoke-command/README.md
+++ b/examples/applications/invoke-command/README.md
@@ -29,7 +29,7 @@ EOF
 Once the service is confirmed registered, the below command can be run to call a command
 on the provider. The command takes a json string and parses it/prints it out on the provider side.
 The 'command' parameter is used to tell the desired provider what command to run.The 'args'
-parameter is a list of arguments for the command. The args can be several types, defined 
+parameter is a list of arguments for the command. The args can be several types, defined
 in `proto\chariott\common\v1\common.proto` file under the `Value` message.
 
 ```bash

--- a/examples/applications/simple-provider/Cargo.toml
+++ b/examples/applications/simple-provider/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "simple-provider"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+async-trait = { workspace = true }
+chariott-common = { workspace = true }
+chariott-proto = { workspace = true }
+ess = { path = "../../../ess/" }
+examples-common = { path = "../../common/" }
+keyvalue = { path = "../../../keyvalue/" }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-stream = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+serde = "1.0.147"
+serde_json = "1.0.87"

--- a/examples/applications/simple-provider/README.md
+++ b/examples/applications/simple-provider/README.md
@@ -1,0 +1,34 @@
+# Simple Provider Example
+
+This is an example Chariott provider that shows how to register a provider with chariott.
+
+## Testing
+
+Start Chariott followed by this application:
+
+```bash
+cargo run -p chariott &
+cargo run -p simple-provider &
+```
+
+Once both are up and running successfully, use the following to 'discover'
+the provider. This will let you know that the provider is registered with Chariott:
+
+```bash
+grpcurl -plaintext -d @ 0.0.0.0:4243 chariott.runtime.v1.ChariottService/Fulfill <<EOF
+{
+  "namespace": "sdv.simple.provider",
+  "intent": {
+    "discover": {}
+  }
+}
+EOF
+```
+
+To clean-up from the above commands, run:
+
+```bash
+pkill simple-provider
+pkill chariott
+pkill grpcurl
+```

--- a/examples/applications/simple-provider/src/chariott_provider.rs
+++ b/examples/applications/simple-provider/src/chariott_provider.rs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use tonic::{Request, Response, Status};
@@ -10,14 +11,14 @@ use url::Url;
 
 use chariott_proto::{
     common::{
-        discover_fulfillment::Service, DiscoverFulfillment, FulfillmentEnum,
-        FulfillmentMessage, IntentEnum
+        discover_fulfillment::Service, DiscoverFulfillment, FulfillmentEnum, FulfillmentMessage,
+        IntentEnum,
     },
     provider::{provider_service_server::ProviderService, FulfillRequest, FulfillResponse},
 };
 
 pub struct ChariottProvider {
-    url: Url
+    url: Url,
 }
 
 impl ChariottProvider {

--- a/examples/applications/simple-provider/src/chariott_provider.rs
+++ b/examples/applications/simple-provider/src/chariott_provider.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+use std::{collections::HashMap};
+
+use async_trait::async_trait;
+use tonic::{Request, Response, Status};
+
+use url::Url;
+
+use chariott_proto::{
+    common::{
+        discover_fulfillment::Service, DiscoverFulfillment, FulfillmentEnum,
+        FulfillmentMessage, IntentEnum
+    },
+    provider::{provider_service_server::ProviderService, FulfillRequest, FulfillResponse},
+};
+
+pub struct ChariottProvider {
+    url: Url
+}
+
+impl ChariottProvider {
+    pub fn new(url: Url) -> Self {
+        Self { url }
+    }
+}
+
+#[async_trait]
+impl ProviderService for ChariottProvider {
+    async fn fulfill(
+        &self,
+        request: Request<FulfillRequest>,
+    ) -> Result<Response<FulfillResponse>, Status> {
+        let fulfillment = match request
+            .into_inner()
+            .intent
+            .and_then(|i| i.intent)
+            .ok_or_else(|| Status::invalid_argument("Intent must be specified."))?
+        {
+            IntentEnum::Discover(_intent) => Ok(FulfillmentEnum::Discover(DiscoverFulfillment {
+                services: vec![Service {
+                    url: self.url.to_string(),
+                    schema_kind: "grpc+proto".to_owned(),
+                    schema_reference: "example.provider.v1".to_owned(),
+                    metadata: HashMap::new(),
+                }],
+            })),
+            _ => Err(Status::unknown("Unsupported or unknown intent."))?,
+        };
+
+        fulfillment.map(|f| {
+            Response::new(FulfillResponse {
+                fulfillment: Some(FulfillmentMessage { fulfillment: Some(f) }),
+            })
+        })
+    }
+}

--- a/examples/applications/simple-provider/src/main.rs
+++ b/examples/applications/simple-provider/src/main.rs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+mod chariott_provider;
+
+use std::{sync::Arc, net::SocketAddr, time::Duration};
+
+use url::Url;
+
+use chariott_common::error::Error;
+use chariott_common::shutdown::RouterExt as _;
+use chariott_proto::{
+    provider::provider_service_server::ProviderServiceServer,
+    runtime::{
+        intent_registration::Intent, intent_service_registration::ExecutionLocality,
+        IntentServiceRegistration, AnnounceRequest, IntentRegistration, RegisterRequest,
+        RegistrationState, chariott_service_client::ChariottServiceClient
+    },
+};
+use examples_common::chariott;
+use tokio::time::sleep;
+use tonic::transport::{Channel, Server};
+use tracing::warn;
+
+use crate::chariott_provider::ChariottProvider;
+
+async fn connect_chariott_client(
+    client: &mut Option<ChariottServiceClient<Channel>>,
+    chariott_url: String
+) -> Result<(), Error> {
+    *client = Some(ChariottServiceClient::connect(chariott_url).await
+        .map_err(|e| {
+            *client = None; // Set client back to None on error.
+            Error::from_error("Could not connect to client", Box::new(e))
+        })?
+    );
+
+    Ok(())
+}
+
+async fn register_announce_once(
+    client: &mut Option<ChariottServiceClient<Channel>>,
+    name: String,
+    version: String,
+    namespace: String,
+    intents: Vec<Intent>,
+    url: String,
+    chariott_url: String,
+    locality: ExecutionLocality
+) -> Result<(), Error> {
+
+    // If there is no client, need to attempt connection.
+    if client.is_none() {
+        connect_chariott_client(client, chariott_url).await?;
+    }
+
+    let service = Some(IntentServiceRegistration {
+        name: name,
+        url: url,
+        version: version,
+        locality: locality as i32,
+    });
+
+    let announce_req = AnnounceRequest {
+        service: service.clone(),
+    };
+
+    // Allways announce to Chariott.
+    let registration_state = client.as_mut()
+        .expect("No client found")
+        .announce(announce_req.clone())
+        .await
+        .map_err(|e| Error::from_error("Error announcing to Chariott.", Box::new(e)))?
+        .into_inner()
+        .registration_state;
+    
+    // Only attempt registration with Chariott if the announced state is ANNOUNCED.
+    // This also handles re-registration if Chariott crashes and comes back online.
+    if registration_state == RegistrationState::Announced as i32 {
+        let register_req = RegisterRequest {
+            service: service.clone(),
+            intents: intents.iter().map(
+                |i| IntentRegistration {
+                    intent: *i as i32,
+                    namespace: namespace.to_string(),
+                }
+            ).collect(),
+        };
+
+        tracing::info!("Registered with Chariott runtime: {:?}", register_req);
+
+        _ = client.as_mut()
+            .expect("No client found")
+            .register(register_req.clone())
+            .await
+            .map_err(|e| Error::from_error("Error registering with Chariott.", Box::new(e)))?;
+    }
+
+    Ok(())
+}
+
+
+async fn register_announce_provider(
+    name: String,
+    version: String,
+    namespace: String,
+    intents: Vec<Intent>,
+    url: String,
+    chariott_url: String,
+    locality: ExecutionLocality,
+    ttl_seconds: u64
+) -> Result<(), Error> {
+
+    // Initiate registration and announce thread.
+    _ = tokio::task::spawn(async move {
+        let mut client = None;
+
+        // Loop that handles provider registration and announce heartbeat pattern.
+        loop {
+            match register_announce_once(
+                &mut client,
+                name.clone(),
+                version.clone(),
+                namespace.clone(),
+                intents.clone(),
+                url.clone(),
+                chariott_url.clone(),
+                locality.clone()
+            ).await {
+                Ok(_) => {},
+                Err(e) => {
+                    warn!(
+                        "Registration failed with '{:?}'. Retrying after {:?}.",
+                        e, ttl_seconds
+                    );
+                }
+            }
+            
+            // Interval between announce heartbeats or connection retries.
+            sleep(Duration::from_secs(ttl_seconds)).await;
+        }
+    });
+
+    Ok(())
+}
+
+// This macro sets up tracing and exit code handling.
+chariott::provider::main!(wain);
+
+async fn wain() -> Result<(), Error> {
+
+    // Intitialize addresses for provider and chariott communication.
+    let chariott_url = "http://0.0.0.0:4243".to_string();
+    let base_provider_address = "0.0.0.0:50064";
+    let provider_url_str = format!("http://{}", base_provider_address.clone());
+    let socket_address: SocketAddr = base_provider_address.clone().parse().map_err(|e| Error::from_error("error getting SocketAddr", Box::new(e)))?;
+    let provider_url: Url = Url::parse(&provider_url_str).map_err(|e| Error::from_error("error getting Url", Box::new(e)))?; 
+
+    // Intitate provider registration and announce heartbeat.
+    register_announce_provider(
+        "sdv.simple.provider".to_string(),
+        "0.0.1".to_string(),
+        "sdv.simple.provider".to_string(),
+        [Intent::Discover].to_vec(),
+        provider_url_str.clone(),
+        chariott_url,
+        ExecutionLocality::Local,
+        5
+    )
+    .await?;
+
+    tracing::info!("Application listening on: {provider_url_str}");
+
+    let provider = Arc::new(ChariottProvider::new(provider_url.clone()));
+
+    Server::builder()
+        .add_service(ProviderServiceServer::from_arc(Arc::clone(&provider)))
+        .serve_with_ctrl_c_shutdown(socket_address)
+        .await
+}

--- a/examples/applications/simple-provider/src/main.rs
+++ b/examples/applications/simple-provider/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
 
 mod chariott_provider;
 
@@ -98,7 +99,6 @@ async fn register_announce_once(
 
     Ok(())
 }
-
 
 async fn register_announce_provider(
     name: String,

--- a/examples/applications/simple-provider/src/main.rs
+++ b/examples/applications/simple-provider/src/main.rs
@@ -115,9 +115,9 @@ async fn register_announce_provider(
         // Loop that handles provider registration and announce heartbeat pattern.
         loop {
             match register_announce_once(&mut client, reg_params.clone()).await {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
-                    warn!("Registration failed with '{:?}'. Retrying after {:?}.",e, ttl_seconds);
+                    warn!("Registration failed with '{:?}'. Retrying after {:?}.", e, ttl_seconds);
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Closes #96 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This provides a self-contained example showing how to register a provider with Chariott. This will make it easier for others to implement a provider, especially in a different language.

## Description
<!--- Describe your changes in detail -->
The example shows an implementation of the register-announce pattern that is described [here](https://github.com/eclipse/chariott/tree/main/examples/applications#provider-registration). The current pattern has a provider registering with Chariott and then sending an announce heartbeat message to Chariott to maintain the connection.
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[docs]: Add self-contained example showing registration of a provider </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
