### PR TITLE
Fix for docker build failure

### DIFF
--- a/.github/workflows/containerize.yaml
+++ b/.github/workflows/containerize.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Find Rust version
         id: rust_version
-        run: echo "::set-output name=RUST_VERSION::$(awk -F "=" '/channel/ {print $2}' rust-toolchain.toml)"
+        run: echo "::set-output name=RUST_VERSION::$(awk -F "=" '/channel/ {gsub(/ /, "", $2); gsub(/"/, "", $2); print $2}' rust-toolchain.toml)"
 
       - name: Set up Docker buildx
         id: buildx

--- a/src/chariott_grpc.rs
+++ b/src/chariott_grpc.rs
@@ -142,7 +142,9 @@ impl<T: Observer + Send + Sync + 'static> ChariottService for ChariottServer<T> 
         #[cfg(not(test))]
         let broker = &self.broker;
         #[cfg(test)]
-        let broker = tests::MockBroker::new(self.broker.clone());
+        let _ = self.broker; // Suppress dead code warning when test feature is active.
+        #[cfg(test)]
+        let broker = tests::MockBroker;
 
         let binding =
             broker.resolve(&config).ok_or_else(|| Status::not_found("No provider found."))?;
@@ -404,11 +406,6 @@ mod tests {
 
     impl MockBroker {
         const RETURN_VALUE: i32 = 10;
-
-        pub fn new(broker: IntentBroker) -> Self {
-            _ = broker; // Suppress dead code warning when test feature is active.
-            Self
-        }
 
         pub fn resolve(&self, _: &IntentConfiguration) -> Option<RuntimeBinding<GrpcProvider>> {
             Some(RuntimeBinding::Test(TestBinding::new(

--- a/src/chariott_grpc.rs
+++ b/src/chariott_grpc.rs
@@ -142,9 +142,7 @@ impl<T: Observer + Send + Sync + 'static> ChariottService for ChariottServer<T> 
         #[cfg(not(test))]
         let broker = &self.broker;
         #[cfg(test)]
-        _ = self.broker; // Suppress dead code warning when test feature is active.
-        #[cfg(test)]
-        let broker = tests::MockBroker;
+        let broker = tests::MockBroker::new(self.broker.clone());
 
         let binding =
             broker.resolve(&config).ok_or_else(|| Status::not_found("No provider found."))?;
@@ -406,6 +404,11 @@ mod tests {
 
     impl MockBroker {
         const RETURN_VALUE: i32 = 10;
+
+        pub fn new(broker: IntentBroker) -> Self {
+            _ = broker; // Suppress dead code warning when test feature is active.
+            Self
+        }
 
         pub fn resolve(&self, _: &IntentConfiguration) -> Option<RuntimeBinding<GrpcProvider>> {
             Some(RuntimeBinding::Test(TestBinding::new(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This provides a quick fix for an issue that causes a dockerfile build to fail when building Chariott with cargo. This issue is not reproducible when directly calling the cargo file.

<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Fixes #103 and #104

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The change is required because dockerfiles cannot currently be built in Chariott.

## Description
<!--- Describe your changes in detail -->
1. Added `let` in front of a line that is used when testing to suppress a dead code warning.
2. Added to a command that gets a rust version from a file when building a container for a git action.
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[fix]: Fixes dockerfile build issue </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
